### PR TITLE
Remove zc155 incontext code

### DIFF
--- a/1_5_5/includes/templates/YOUR_CLASSIC_RESPONSIVE/templates/tpl_checkout_confirmation_default.php
+++ b/1_5_5/includes/templates/YOUR_CLASSIC_RESPONSIVE/templates/tpl_checkout_confirmation_default.php
@@ -202,7 +202,7 @@
 ?>
 
 <?php
-  echo zen_draw_form('checkout_confirmation', $form_action_url, 'post', 'id="checkout_confirmation" onsubmit="submitonce();"' . (is_array($payment_modules->modules) ? $payment_modules->process_form_params() : ''));
+  echo zen_draw_form('checkout_confirmation', $form_action_url, 'post', 'id="checkout_confirmation" onsubmit="submitonce();"');
 
   if (is_array($payment_modules->modules)) {
     echo $payment_modules->process_button();

--- a/1_5_5/includes/templates/YOUR_TEMPLATE/templates/tpl_checkout_confirmation_default.php
+++ b/1_5_5/includes/templates/YOUR_TEMPLATE/templates/tpl_checkout_confirmation_default.php
@@ -202,7 +202,7 @@
 ?>
 
 <?php
-  echo zen_draw_form('checkout_confirmation', $form_action_url, 'post', 'id="checkout_confirmation" onsubmit="submitonce();"' . (is_array($payment_modules->modules) ? $payment_modules->process_form_params() : ''));
+  echo zen_draw_form('checkout_confirmation', $form_action_url, 'post', 'id="checkout_confirmation" onsubmit="submitonce();"');
 
   if (is_array($payment_modules->modules)) {
     echo $payment_modules->process_button();


### PR DESCRIPTION
Fixes #43.

In development of the changes for ZC 1.5.5, there was an expectation that other proposed code to further support use of PayPal InContext would be incorporated, see [ZC Issue #1192](https://github.com/zencart/zencart/issues/1192).  As such, the same code was carried over to the ZC 1.5.5 version of the same modified file for SBA.  As of ZC 1.5.5d, the change has not been incorporated and is causing the error that is described at issue #43.  The applicable code is being restored to be closer to what is really the ZC 1.5.5 version of includes/modules/templates/template_default/templates/tpl_checkout_confirmation_default.php and includes/modules/templates/responsive_classic/templates/tpl_checkout_confirmation_default.php