### PR TITLE
added GROUP BY configuration_group_id for strict sql modes

### DIFF
--- a/admin/stock_by_attr_install.php
+++ b/admin/stock_by_attr_install.php
@@ -565,7 +565,11 @@ function insertDynDropdownsConfigurationMenu(){
 
   //get current max sort number used, then add 1 to it.
   //this will place the new entry 'productsWithAttributesStock' at the bottom of the list
-  $sql = "SELECT configuration_group_id, MAX(configuration_group_id) as last_configuration_group_id FROM ".TABLE_CONFIGURATION_GROUP." WHERE configuration_group_title='Dynamic Drop Downs' LIMIT 1";
+  $sql = "SELECT configuration_group_id, MAX(configuration_group_id) AS last_configuration_group_id
+          FROM " . TABLE_CONFIGURATION_GROUP . "
+          WHERE configuration_group_title = 'Dynamic Drop Downs'
+          GROUP BY configuration_group_id
+          LIMIT 1";
   $result = $db->Execute($sql);
   $configuration_id = $result->fields['configuration_group_id'];
   if($configuration_id=='' || $configuration_id == '0') {


### PR DESCRIPTION
Needed to add GROUP BY configuration_group_id to the query, or i would get an error
`Fatal error:  1140:In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column 'sba.configuration_group.configuration_group_id'; this is incompatible with sql_mode=only_full_group_by`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mc12345678/stock_by_attributes_combined/53)
<!-- Reviewable:end -->
