### PR TITLE
Remove class ReflectionFunction from session

### DIFF
--- a/includes/classes/class.products_with_attributes_class_stock.php
+++ b/includes/classes/class.products_with_attributes_class_stock.php
@@ -40,9 +40,14 @@ class products_with_attributes_class_stock extends base {
 
   function __construct() {
     $this->_isSBA = array();
+    $this->zgapf = false;
     if (function_exists('zen_get_attributes_price_final')) {
       if (class_exists('ReflectionFunction')) {
-        $this->zgapf = new ReflectionFunction('zen_get_attributes_price_final');
+        $zgapf = new ReflectionFunction('zen_get_attributes_price_final');
+        if ($zgapf->getNumberOfParameters() > 4) {
+          $this->zgapf = true;
+        }
+        unset ($zgapf);
       }
     }
   }

--- a/includes/classes/observers/class.products_with_attributes_stock.php
+++ b/includes/classes/observers/class.products_with_attributes_stock.php
@@ -451,7 +451,7 @@ class products_with_attributes_stock extends base {
       // START "Stock by Attributes" SBA added original price for display, and some formatting
       $originalpricedisplaytext = null;
 
-      if (isset($_SESSION['pwas_class2']->zgapf) && $_SESSION['pwas_class2']->zgapf->getNumberOfParameters() > 4) {
+      if (!empty($this->zgapf)) {
         // Use the latest function for determining the attribute's final price
         //   This requires/uses 4 parameters to internally determine the price of the attribute
         global $products_price_is_priced_by_attributes;

--- a/includes/classes/pad_base.php
+++ b/includes/classes/pad_base.php
@@ -102,7 +102,11 @@ $this->products_original_price = $tax_class_array->fields['products_price']; /* 
 
       if (function_exists('zen_get_attributes_price_final')) {
         if (class_exists('ReflectionFunction')) {
-          $this->zgapf = new ReflectionFunction('zen_get_attributes_price_final');
+          $zgapf = new ReflectionFunction('zen_get_attributes_price_final');
+          if ($zgapf->getNumberOfParameters() > 4) {
+            $this->zgapf = true;
+          }
+          unset ($zgapf);
         }
       }
 

--- a/includes/classes/pad_sba_sequenced_dropdowns.php
+++ b/includes/classes/pad_sba_sequenced_dropdowns.php
@@ -654,6 +654,7 @@ Array(
             $option_price = $products_options->fields['options_values_price']; //<- to display "normal" price, otherwise set to '0' to not attach/display price in field.
 
 // mc12345678 2017-06-25 BOF edited to support wholesale display
+
 if (!empty($_SESSION['customer_id'])) {
     $customers_id = (int)$_SESSION['customer_id'];
     $customer_check = $db->Execute("select * from " . TABLE_CUSTOMERS . " where customers_id = $customers_id");
@@ -671,20 +672,12 @@ if (!empty($_SESSION['customer_id'])) {
         $option_price = $products_options->fields['options_values_price'];
       }
 //      $option_price = (float)$products_options->fields['options_values_price_w'] /*+ $products_options->fields['options_values_price']*/;
-    } else {
-      if ($products_options->fields['attributes_discounted'] == 1) {
-        if (isset($this->zgapf) && $this->zgapf->getNumberOfParameters() > 4) {
-          $option_price = zen_get_attributes_price_final($products_options->fields['products_attributes_id'], 1, '', 'false', $products_price_is_priced_by_attributes);
-        } else {
-          $option_price = zen_get_attributes_price_final($products_options->fields['products_attributes_id'], 1, '', 'false');
-          $option_price = zen_get_discount_calc($this->products_id, true, $option_price);
-        }
-      }
     }
+}
 
-} else {
+if (empty($_SESSION['customer_id']) || !(!empty($customer_check->fields['customers_whole']) && !empty($_SESSION['customer_whole']) && (int)$_SESSION['customer_whole'] > 0)) {
   if ($products_options->fields['attributes_discounted'] == 1) {
-    if (isset($this->zgapf) && $this->zgapf->getNumberOfParameters() > 4) {
+    if (!empty($this->zgapf)) {
       $option_price = zen_get_attributes_price_final($products_options->fields['products_attributes_id'], 1, '', 'false', $products_price_is_priced_by_attributes);
     } else {
       $option_price = zen_get_attributes_price_final($products_options->fields['products_attributes_id'], 1, '', 'false');


### PR DESCRIPTION
Remove class ReflectionFunction from session
    
Because SBA stores data as a session, it appears that in `PHP 7.4.3` that
it is unable to properly address the `ReflectionFunction` class when it
was used the way it was in this module.  To continue use of its functionality
the result has been refactored to support `PHP 7.4.3`.