### PR TITLE
Eliminate PHP notice in checking variable value.

### DIFF
--- a/includes/classes/pad_base.php
+++ b/includes/classes/pad_base.php
@@ -378,7 +378,7 @@ $this->products_original_price = $tax_class_array->fields['products_price']; /* 
           }
 
           /// Start of Changes- display actual prices instead of +/- Actual Price Pull Down v1.2.3a
-          $new_price ? $original_price = $new_price : $original_price = $this->products_original_price; //// check if set special price note $this variable
+          isset($new_price) ? $original_price = $new_price : $original_price = $this->products_original_price; //// check if set special price note $this variable
 
           $option_price = $products_options->fields['options_values_price'];
           if ($products_options->fields['price_prefix'] == "-") // in case price lowers, don't add values, subtract.


### PR DESCRIPTION
This tests to see if `$new_price` is set, if it is set, then use that
value (whether it is zero or not).  I still am not sure exactly why it
is in here, but may exist for some other use.  In absence of it
being set (default) use the value on the right.  It offers a sort of
test variable; however, such testing could have been accomplished by
other means.