### PR TITLE
Add `$params` to the radio field for single value dropdown.

### DIFF
--- a/includes/modules/YOUR_TEMPLATE/attributes.php
+++ b/includes/modules/YOUR_TEMPLATE/attributes.php
@@ -619,7 +619,7 @@ $sql = "select count(*) as total
                     $options_name[] = $products_options_names->fields['products_options_name'];
                   }
                   $options_html_id[] = 'drprad-attrib-' . $products_options_names->fields['products_options_id'];
-                  $options_menu[] = zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']', $products_options_value_id, true, 'id="' . 'attrib-' . $products_options_names->fields['products_options_id'] . '-' . $products_options_value_id . '"') . '<label class="attribsRadioButton" for="' . 'attrib-' . $products_options_names->fields['products_options_id'] . '-' . $products_options_value_id . '">' . $products_options_details . '</label>' . "\n";
+                  $options_menu[] = zen_draw_radio_field('id[' . $products_options_names->fields['products_options_id'] . ']', $products_options_value_id, true, 'id="' . 'attrib-' . $products_options_names->fields['products_options_id'] . '-' . $products_options_value_id . '"' . $params) . '<label class="attribsRadioButton" for="' . 'attrib-' . $products_options_names->fields['products_options_id'] . '-' . $products_options_value_id . '">' . $products_options_details . '</label>' . "\n";
                   $options_comment[] = $products_options_names->fields['products_options_comment'];
                   $options_comment_position[] = ($products_options_names->fields['products_options_comment_position'] == '1' ? '1' : '0');
                   break;


### PR DESCRIPTION
When a dropdown has a single option value it is turned into a radio button.
This allows the `$params` variable to be applied in that situation.