### PR TITLE
Handle relocation of notifier for copying attributes.

### DIFF
--- a/1_5_1/admin/product.php
+++ b/1_5_1/admin/product.php
@@ -249,10 +249,10 @@ if ($action == 'new_product_meta_tags') {
           $contents[] = array('text' => '<br />' . TEXT_COPY_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_attributes', 'copy_attributes_yes', true) . ' ' . TEXT_COPY_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_attributes', 'copy_attributes_no') . ' ' . TEXT_COPY_ATTRIBUTES_NO);
 // future          $contents[] = array('align' => 'center', 'text' => '<br />' . ATTRIBUTES_NAMES_HELPER . '<br />' . zen_draw_separator('pixel_trans.gif', '1', '10'));
           $contents[] = array('text' => '<br />' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif','','100%','3'));
-          // BOF Added for Stock By Attributes SBA - mc12345678 1 of 1
-          $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
-          // EOF Added for Stock By Attributes SBA - mc12345678 1 of 1
         }
+        // BOF Added for Stock By Attributes SBA - mc12345678 1 of 1 - relocated 2021-02-07 for https://github.com/zencart/zencart/issues/4199
+        $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
+        // EOF Added for Stock By Attributes SBA - mc12345678 1 of 1
 
         // only ask if product has discounts
         if (zen_has_product_discounts($pInfo->products_id) == 'true') {

--- a/1_5_3 and 1_5_4/admin/product.php
+++ b/1_5_3 and 1_5_4/admin/product.php
@@ -250,10 +250,10 @@ if ($action == 'new_product_meta_tags') {
           $contents[] = array('text' => '<br />' . TEXT_COPY_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_attributes', 'copy_attributes_yes', true) . ' ' . TEXT_COPY_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_attributes', 'copy_attributes_no') . ' ' . TEXT_COPY_ATTRIBUTES_NO);
 // future          $contents[] = array('align' => 'center', 'text' => '<br />' . ATTRIBUTES_NAMES_HELPER . '<br />' . zen_draw_separator('pixel_trans.gif', '1', '10'));
           $contents[] = array('text' => '<br />' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif','','100%','3'));
-          // BOF Added for Stock By Attributes SBA - mc12345678
-          $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
-          // EOF Added for Stock By Attributes SBA - mc12345678
         }
+        // BOF Added for Stock By Attributes SBA - mc12345678 - relocated 2021-02-07 for https://github.com/zencart/zencart/issues/4199
+        $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
+        // EOF Added for Stock By Attributes SBA - mc12345678
 
         // only ask if product has discounts
         if (zen_has_product_discounts($pInfo->products_id) == 'true') {

--- a/1_5_5/admin/product.php
+++ b/1_5_5/admin/product.php
@@ -232,10 +232,10 @@ if ($action == 'new_product_meta_tags') {
           $contents[] = array('text' => '<br />' . TEXT_COPY_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_attributes', 'copy_attributes_yes', true) . ' ' . TEXT_COPY_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_attributes', 'copy_attributes_no') . ' ' . TEXT_COPY_ATTRIBUTES_NO);
 // future          $contents[] = array('align' => 'center', 'text' => '<br />' . ATTRIBUTES_NAMES_HELPER . '<br />' . zen_draw_separator('pixel_trans.gif', '1', '10'));
           $contents[] = array('text' => '<br />' . zen_image(DIR_WS_IMAGES . 'pixel_black.gif','','100%','3'));
-          // BOF Added for Stock By Attributes SBA - mc12345678
-          $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
-          // EOF Added for Stock By Attributes SBA - mc12345678
         }
+        // BOF Added for Stock By Attributes SBA - mc12345678 - relocated 2021-02-07 for https://github.com/zencart/zencart/issues/4199
+        $zco_notifier->notify('NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES', $pInfo, $contents);
+        // EOF Added for Stock By Attributes SBA - mc12345678
 
         // only ask if product has discounts
         if (zen_has_product_discounts($pInfo->products_id) == 'true') {

--- a/admin/includes/classes/observers/class.products_with_attributes_stock.php
+++ b/admin/includes/classes/observers/class.products_with_attributes_stock.php
@@ -172,20 +172,26 @@ class products_with_attributes_stock_admin extends base {
       include DIR_WS_LANGUAGES . 'english' . '/modules/product_sba.php';
     }
     
-    if ($products_with_attributes_stock_class->zen_product_is_sba($pInfo->products_id)){
-      $last_content = array();
-      // Remove last item from the $contents array (assumes that the divider line has been added, value of 1 represents how many to remove)
-      for ($i = 0; $i < 1; $i++) {
-        $last_content[] = array_pop($contents);
-      }
-      //$last_content = $contents[count($contents) - 2];
-      //$contents[count($contents) - 2] = array('text' => '<br />' . TEXT_COPY_SBA_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_yes', true) . ' ' . TEXT_COPY_SBA_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_no') . ' ' . TEXT_COPY_SBA_ATTRIBUTES_NO);
-      //$contents[] = $last_content;
-      $contents[] = array('text' => '<br />' . TEXT_COPY_SBA_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_yes', true) . ' ' . TEXT_COPY_SBA_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_no') . ' ' . TEXT_COPY_SBA_ATTRIBUTES_NO);
-      // Re-add the removed $contents item(s).
-      while (!empty($last_content)) {
-        $contents[] = array_pop($last_content);
-      }
+    if (!$products_with_attributes_stock_class->zen_product_is_sba($pInfo->products_id)){
+      return;
+    }
+
+    if (!zen_has_product_attributes($pInfo->products_id, 'false') {
+      return;
+    }
+
+    $last_content = array();
+    // Remove last item from the $contents array (assumes that the divider line has been added, value of 1 represents how many to remove)
+    for ($i = 0; $i < 1; $i++) {
+      $last_content[] = array_pop($contents);
+    }
+    //$last_content = $contents[count($contents) - 2];
+    //$contents[count($contents) - 2] = array('text' => '<br />' . TEXT_COPY_SBA_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_yes', true) . ' ' . TEXT_COPY_SBA_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_no') . ' ' . TEXT_COPY_SBA_ATTRIBUTES_NO);
+    //$contents[] = $last_content;
+    $contents[] = array('text' => '<br />' . TEXT_COPY_SBA_ATTRIBUTES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_yes', true) . ' ' . TEXT_COPY_SBA_ATTRIBUTES_YES . '<br />' . zen_draw_radio_field('copy_sba_attributes', 'copy_sba_attributes_no') . ' ' . TEXT_COPY_SBA_ATTRIBUTES_NO);
+    // Re-add the removed $contents item(s).
+    while (!empty($last_content)) {
+      $contents[] = array_pop($last_content);
     }
   }
   


### PR DESCRIPTION
Notifier 'NOTIFY_ADMIN_PRODUCT_COPY_TO_ATTRIBUTES' was requested to be
moved outside of the specific grouping for checking if a product has
attributes.  This was agreed upon so had to ensure that the code would
still work properly. Wanted to be sure to provide/force consistency
where able.  Unfortunately the notifier is in code that doesn't require
modification for operation so it may/may not be inside/outside the
code grouping depending on which version is loaded, etc...

Fixes #98 