### PR TITLE
Correct language conversion

### DIFF
--- a/admin/includes/languages/dutch/extra_definitions/lang.reg_ddsba.php
+++ b/admin/includes/languages/dutch/extra_definitions/lang.reg_ddsba.php
@@ -1,6 +1,6 @@
 <?php
 if (! defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access',
+  die('Illegal Access');
 }
 if (!defined('BOX_CONFIGURATION_DYNAMIC_DROPDOWNS')) $define = [
     'BOX_CONFIGURATION_DYNAMIC_DROPDOWNS' => 'Dynamic Drop Downs',

--- a/admin/includes/languages/english/extra_definitions/lang.reg_ddsba.php
+++ b/admin/includes/languages/english/extra_definitions/lang.reg_ddsba.php
@@ -1,6 +1,6 @@
 <?php
 if (! defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access',
+  die('Illegal Access');
 }
 if (!defined('BOX_CONFIGURATION_DYNAMIC_DROPDOWNS')) $define = [
     'BOX_CONFIGURATION_DYNAMIC_DROPDOWNS' => 'Dynamic Drop Downs',

--- a/admin/includes/languages/french/extra_definitions/lang.reg_ddsba.php
+++ b/admin/includes/languages/french/extra_definitions/lang.reg_ddsba.php
@@ -1,6 +1,6 @@
 <?php
 if (! defined('IS_ADMIN_FLAG')) {
-  die('Illegal Access',
+  die('Illegal Access');
 }
 if (!defined('BOX_CONFIGURATION_DYNAMIC_DROPDOWNS')) $define = [
     'BOX_CONFIGURATION_DYNAMIC_DROPDOWNS' => 'Dynamic Drop Downs',


### PR DESCRIPTION
Process to convert former language files to those used by Zen Cart 1.5.8, didn't translate a `die` statement correctly and caused a php error when relied on as the only language file.